### PR TITLE
Improvements

### DIFF
--- a/app/controllers/redsys/tpv_controller.rb
+++ b/app/controllers/redsys/tpv_controller.rb
@@ -13,7 +13,7 @@ module Redsys
     # - url_ko:string => url de vuelta del tpv cuando ocurre un error
     #
     def form
-      amount = BigDecimal.new(params[:amount] || '0')
+      amount = BigDecimal(params[:amount] || '0')
       order = params[:order] || '0'
       language = params[:language]
       url_ok = params[:url_ok]
@@ -21,7 +21,14 @@ module Redsys
       merchant_url = params[:merchant_url] || redsys_notification_url if defined?(redsys_notification_url)
       merchant_name = params[:merchant_name]
       product_description = params[:product_description]
+
       @tpv = Redsys::Tpv.new(amount, order, language, merchant_url, url_ok, url_ko, merchant_name, product_description)
+
+      if params[:angular_request].present? && params[:angular_request] == "true"
+        render json: { tpv_form: @tpv.to_json }
+      else
+        render :form
+      end
     end
     
   end

--- a/app/models/redsys/tpv.rb
+++ b/app/models/redsys/tpv.rb
@@ -1,7 +1,6 @@
 require 'openssl'
 require 'base64'
 require 'json'
-require 'rails-i18n'
 
 module Redsys
   class Tpv
@@ -92,6 +91,15 @@ module Redsys
     def response_signature(response_data)
       # For checking the received signature from the gateway
       urlsafe_encrypt_mac256(response_data, calculate_key)
+    end
+
+    def to_json
+      {
+        url: Rails.configuration.redsys_rails[:url],
+        signature_version: Redsys::Tpv.signature_version,
+        merchant_params: merchant_params,
+        merchant_signature: merchant_signature
+      }
     end
 
     private


### PR DESCRIPTION
1. Remove 'rails-i18n', because it does not use and does not exist on dependencies
2. Add availability to API responds to use it with angularjs (for example)
3. BigDecimal.new replaced with BigDecimal (because of deprecated)